### PR TITLE
removed the check to only place commas (,) when the item of an array …

### DIFF
--- a/lib/Node/ParameterNode.php
+++ b/lib/Node/ParameterNode.php
@@ -39,11 +39,7 @@ class ParameterNode extends Node
 		foreach( $this->getChildren() as $child )
 		{
 			$child->compile( $compiler );
-
-			if( ! ( end( $this->getChildren() ) === $child ) )
-			{
-				$compiler->writeBody( ',' );
-			}
+			$compiler->writeBody( ',' );
 		}
 
 		$compiler->writeBody( ']' );


### PR DESCRIPTION
…is the last one, since php's syntax allows for commas after every item in an array